### PR TITLE
Convert models to use ES6 classes

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,16 @@
+{
+  "camelcase": true,
+  "curly": true,
+  "eqeqeq": true,
+  "freeze": true,
+  "indent": 2,
+  "newcap": true,
+  "quotmark": "single",
+  "maxdepth": 3,
+  "maxstatements": 15,
+  "maxlen": 100,
+  "eqnull": true,
+  "funcscope": true,
+  "node": true,
+  "strict" : true
+}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APP_NAME=grpn-facets
 
-NODE=node
+NODE=node --harmony
 NPM=npm
 FOREVER=forever
 

--- a/src/models/contributor.js
+++ b/src/models/contributor.js
@@ -1,32 +1,35 @@
+'use strict';
+
 var Model = require('../models/model'),
   config = require('../../config');
 
-// Constructor
-function Contributor(){
-  this.query = {
-    apikey: config.apiKey
-  };
-  this.endpoint = '/contributors.json';
-  this.url = config.urls.transparency + 'aggregates/pol/';
-}
+class Contributor extends Model {
 
-Contributor.prototype = new Model();
+  constructor() {
+    this.query = {
+      apikey: config.apiKey
+    };
+    this.endpoint = '/contributors.json';
+    this.url = config.urls.transparency + 'aggregates/pol/';
+  }
 
-Contributor.prototype.findById = function( query, callback ){
-  this.url += query.id;
-  this.find( query, callback );
-};
+  findById(query, callback) {
+    this.url += query.id;
+    this.find(query, callback);
+  }
 
-Contributor.prototype.formatResponse = function( body ){
-  var parsedBody = JSON.parse( body ),
+  formatResponse(body) {
+    var parsedBody = JSON.parse( body ),
     results = parsedBody.filter(function(item){
       // `undefined != null` coerces undefined to null
       return item.id != null;
     });
 
-  return {
-    contributors: results
-  };
-};
+    return {
+      contributors: results
+    };
+  }
+  
+}
 
 module.exports = Contributor;

--- a/src/models/entity.js
+++ b/src/models/entity.js
@@ -1,25 +1,28 @@
+'use strict';
+
 var Model = require('../models/model'),
   config = require('../../config');
 
-// Constructor
-function Entity(){
-  this.query = {
-    apikey: config.apiKey
-  };
-  this.endpoint = 'entities/id_lookup.json';
-  this.url = config.urls.transparency;
-}
-
-Entity.prototype = new Model();
-
-Entity.prototype.findId = function( query, callback ){
-  this.find( query, callback );
-};
-
-Entity.prototype.formatResponse = function( body ){
-  if(body){
-    return JSON.parse( body )[0].id;
+class Entity extends Model{
+  
+  constructor() {
+    this.query = {
+      apikey: config.apiKey
+    };
+    this.endpoint = 'entities/id_lookup.json';
+    this.url = config.urls.transparency;
   }
-};
+
+  findId(query, callback) {
+    this.find(query, callback);
+  }
+
+  formatResponse(body) {
+    if (body) {
+      return JSON.parse(body)[0].id;
+    }
+  }
+  
+}
 
 module.exports = Entity;

--- a/src/models/industry.js
+++ b/src/models/industry.js
@@ -1,32 +1,35 @@
+'use strict';
+
 var Model = require('../models/model'),
   config = require('../../config');
 
-// Constructor
-function Industry(){
-  this.query = {
-    apikey: config.apiKey
-  };
-  this.endpoint = '/contributors/industries.json';
-  this.url = config.urls.transparency + 'aggregates/pol/';
-}
+class Industry extends Model {
 
-Industry.prototype = new Model();
+  constructor() {
+    this.query = {
+      apikey: config.apiKey
+    };
+    this.endpoint = '/contributors/industries.json';
+    this.url = config.urls.transparency + 'aggregates/pol/';
+  }
 
-Industry.prototype.findById = function( query, callback ){
-  this.url += query.id;
-  this.find( query, callback );
-};
+  findById(query, callback) {
+    this.url += query.id;
+    this.find(query, callback);
+  }
 
-Industry.prototype.formatResponse = function( body ){
-  var parsedBody = JSON.parse( body ),
+  formatResponse(body) {
+    var parsedBody = JSON.parse( body ),
 
     results = parsedBody.filter(function(item){
       return item.id != null;
     });
 
-  return {
-    industries: results
-  };
-};
+    return {
+      industries: results
+    };
+
+  }
+}
 
 module.exports = Industry;

--- a/src/models/legislator.js
+++ b/src/models/legislator.js
@@ -1,14 +1,16 @@
+'use strict';
+
 var Model = require('../models/model'),
   config = require('../../config');
 
-// Constructor
-function Legislator(){
-  this.query = null;
-  this.responseKey = 'legislators';
-  this.endpoint = 'legislators';
-  this.url = config.urls.congress;
+class Legislator extends Model {
+    
+  constructor() {
+    this.query = null;
+    this.responseKey = 'legislators';
+    this.endpoint = 'legislators';
+    this.url = config.urls.congress;
+  }
 }
-
-Legislator.prototype = new Model();
 
 module.exports = Legislator;

--- a/src/models/model.js
+++ b/src/models/model.js
@@ -1,62 +1,65 @@
+'use strict';
+
 var request =       require('request'),
   queryString =   require('querystring'),
   merge =         require('merge');
 
-// Constructor
-function Model(){
-  this.query = null;
-  this.responseKey = null;
-  this.endpoint = null;
-  this.url = null;
-}
+class Model {
 
-// Properties
-Model.prototype.headers = {
-  'content-type': 'application/json; charset=UTF-8',
-  'X-APIKEY': '66603c029b1b49428da28d6a783f795e'
-};
+  constructor() {
+    this.query = null;
+    this.responseKey = null;
+    this.endpoint = null;
+    this.url = null;
+    this.headers = {
+      'content-type': 'application/json; charset=UTF-8',
+      'X-APIKEY': '66603c029b1b49428da28d6a783f795e'
+    };
+  }
 
+  find(query, callback) {
+    this.query = merge(this.query, query);
+    this.options = this.createHashOptions.call(this);
+    this.makeRequest.call(this, callback);
+  }
 
-Model.prototype.find = function( query, callback ){
-  this.query = merge(this.query, query);
-  this.options = createHashOptions.call( this );
-  makeRequest.call( this, callback );
-};
-
-
-function createHashOptions(){
-  var query = queryString.stringify( this.query ),
+  createHashOptions() {
+    var query = queryString.stringify(this.query),
     options = {
       url: this.url + this.endpoint,
       method: 'GET',
       headers: this.headers
     };
 
-  if ( query ) {
-    options.url = options.url  + '?' + query;
+    if ( query ) {
+      options.url = options.url  + '?' + query;
+    }
+
+    return options;
   }
 
-  return options;
-}
+  makeRequest(callback) {
 
-function makeRequest( callback ){
-  var _this = this,
+    var _this = this,
     options = this.options;
 
-  request( options, function ( error, response, body ){
-    var responseData;
+    request(options, function (error, response, body) {
+      var responseData;
 
-    if (!error && response.statusCode == 200) {
-      responseData = _this.formatResponse( body );
-      callback( responseData );
-    }
-  });
+      if (!error && response.statusCode === 200) {
+        responseData = _this.formatResponse( body );
+        callback( responseData );
+      }
+    });
+
+  }
+
+  formatResponse(body) {
+    var responseData = {};
+    responseData[ this.responseKey ] = JSON.parse( body ).results;
+    return responseData;
+  }
+  
 }
-
-Model.prototype.formatResponse = function( body ){
-  var responseData = {};
-  responseData[ this.responseKey ] = JSON.parse( body ).results;
-  return responseData;
-};
 
 module.exports = Model;


### PR DESCRIPTION
This PR converts all the models to use ES6 classes. As [the io.js site notes](https://iojs.org/en/es6.html), ES6 classes are still in the staging branch, so in order to use them the app must be run with the ```--harmony``` flag for now. 

ES6 classes require the use of strict mode, so I've added the ```'use strict'``` declaration at the top of the model files. I also added a ```.jshintrc``` file to help me stick to the coding style I'm using. Feel free to make changes to it. 

The controller still needs to be converted, and a little refactoring probably needs to be done still for the model classes.